### PR TITLE
Avoid deadlock, harden against non-compliant walk responses

### DIFF
--- a/kext/proto.c
+++ b/kext/proto.c
@@ -115,6 +115,10 @@ walk_9p(mount_9p *nmp, fid_9p fid, char *name, int nname, fid_9p *fidp, qid_9p *
 	if (e)
 		return e;
 
+	// Hardening
+	if (name && rx.nwqid == 0)
+		return ENOENT;
+
 	*fidp = tx.newfid;
 	if(rx.nwqid == 0)
 		*qid = rx.qid;

--- a/kext/vnops.c
+++ b/kext/vnops.c
@@ -288,8 +288,10 @@ vnop_lookup_9p(struct vnop_lookup_args *ap)
 			else if (ismkentry(cnp) && dnp->dir.qid.vers!=0)
 				cache_enter(dvp, NULL, cnp);
 		}
+		nunlock_9p(dnp);
 		goto error;
 	}
+	nunlock_9p(dnp);
 
 	e = nget_9p(dnp->nmp, fid, qid, dvp, vpp, cnp, ap->a_context);
 	if (e || *vpp==NULL || NTO9P(*vpp)->fid!=fid) 
@@ -299,7 +301,6 @@ vnop_lookup_9p(struct vnop_lookup_args *ap)
 		nunlock_9p(NTO9P(*vpp));
 
 error:
-	nunlock_9p(dnp);
 	return e;
 }
 #undef isop


### PR DESCRIPTION
Mac9P kept locking up in a deadlock against my 9p test server. After some debugging (which is kind of troublesome on El Capitan without the ability to print lock pointers - they're replaced with "<ptr>", even if you try to trick it!), I found that nget_9p seemed to try to take a lock that vnop_lookup_9p, the caller, was holding. I'm a bit tired (submitting a PR at ~02:00), so I might have done something stupid, but the change seems like it makes sense, and my kernel isn't locking up anymore.

Second, I found that my 9p server replied with an Rwalk with 0 qids when a Twalk with 1 name was issued on a non-existant name, with mac9p only understanding Rerror in this case, the result being mac9p thinking the walk succeeded. Various other 9p client implementations (including the plan9 kernel itself, IIRC) tolerated this behaviour (nwqid < nwname means that the walk did not succeed in the general case, it's only nwname == 1 that's special), so I added the same tolerance to mac9p (yes, I also fixed my server).

Things seem to work now, all except being unable to append to files from zsh (echo "test" >> test), even though it works with bash(!?).
