### PR TITLE
Add support for O_NOCTTY

### DIFF
--- a/kext/vnops.c
+++ b/kext/vnops.c
@@ -448,8 +448,8 @@ vnop_open_9p(struct vnop_open_args *ap)
 
 	mode = flags & O_ACCMODE;
 	CLR(flags, O_ACCMODE);
-    
-	CLR(flags, O_DIRECTORY|O_NONBLOCK|O_EXCL|O_NOFOLLOW);
+
+	CLR(flags, O_DIRECTORY|O_NONBLOCK|O_EXCL|O_NOFOLLOW|O_NOCTTY);
 	CLR(flags, O_APPEND);
 
 	/* locks implemented on the vfs layer */


### PR DESCRIPTION
O_NOCTTY is used to avoid making the file to be opened a controlling TTY if the file is a TTY. This doesn't affect 9P, however, so we should just dump the flag, rather than return "operation not supported".

This fixes #2.
