### PR TITLE
Harden against walks that don't fail but instead return len(qids)<len(names)

### DIFF
--- a/kext/proto.c
+++ b/kext/proto.c
@@ -115,6 +115,10 @@ walk_9p(mount_9p *nmp, fid_9p fid, char *name, int nname, fid_9p *fidp, qid_9p *
 	if (e)
 		return e;
 
+	// Hardening
+	if (name && rx.nwqid == 0)
+		return ENOENT;
+
 	*fidp = tx.newfid;
 	if(rx.nwqid == 0)
 		*qid = rx.qid;


### PR DESCRIPTION
My server implementation did not return Rerror if the first element did not exist, but instead returned 0 qids. Other client implementations used for testing accepted this as a failed walk, but mac9p considered it a successful walk, making any attempt at making a file fail with "file already exists".

This fixes #5.
