### PR TITLE
Fix deadlock

### DIFF
--- a/kext/vnops.c
+++ b/kext/vnops.c
@@ -288,8 +288,10 @@ vnop_lookup_9p(struct vnop_lookup_args *ap)
 			else if (ismkentry(cnp) && dnp->dir.qid.vers!=0)
 				cache_enter(dvp, NULL, cnp);
 		}
+		nunlock_9p(dnp);
 		goto error;
 	}
+	nunlock_9p(dnp);
 
 	e = nget_9p(dnp->nmp, fid, qid, dvp, vpp, cnp, ap->a_context);
 	if (e || *vpp==NULL || NTO9P(*vpp)->fid!=fid) 
@@ -299,7 +301,6 @@ vnop_lookup_9p(struct vnop_lookup_args *ap)
 		nunlock_9p(NTO9P(*vpp));
 
 error:
-	nunlock_9p(dnp);
 	return e;
 }
 #undef isop


### PR DESCRIPTION
nget_9p would freeze when tested against my server consistently. Trying to list the mounted directory would block indefinitely, and it would also be impossible to unmount or unload the kext.

The issue appears to be an attempt to lock the node_9p structure twice, first in vnop_lookup_9p, then in nget_9p. To fix this, the node_9p struct is unlocked immediately before nget_9p.

I am unsure if this is semantically in line with where the locks were supposed to be held. An alternative fix would be to change how nget_9p handles locking internally.

Fixes #4 
